### PR TITLE
Support for "try" and "optional" modes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ internals.implementation = function (server, options) {
 
             if (!request.headers.authorization ||
                 request.headers.authorization === undefined) {
-                return reply(Boom.unauthorized('NO_AUTHORIZATION_HEADER', 'bearerAuth'), null, {});
+                return reply(Boom.unauthorized(null, 'bearerAuth'), null, {});
             }
 
             var headerParts = request.headers.authorization.split(' ');

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "lab": "6.2.0",
     "code": "1.5.0",
-    "hapi": "11.0.1"
+    "hapi": "11.0.x"
   },
   "peerDependencies": {
     "hapi": ">=11.x.x"


### PR DESCRIPTION
If the authorization header is missing we need to pass null as the error message, otherwise hapi will not try other strategies. It will also fail if the mode is on 'try'.