### PR TITLE
Return unauthorized on wrong header format to allow chaining of other header based strategies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ internals.implementation = function (server, options) {
             const headerParts = request.headers.authorization.split(' ');
 
             if (headerParts[0].toLowerCase() !== 'bearer') {
-                return reply(Boom.badRequest('Token should be given in the Authorization header in "Bearer [token]" form. Example: "Authorization: Bearer azertyuiop0123"'));
+                return reply(Boom.unauthorized(null, 'bearerAuth'));
             }
 
             const token = headerParts[1];

--- a/test/index.js
+++ b/test/index.js
@@ -234,6 +234,7 @@ lab.experiment('hapi-auth-bearer-simple', () => {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(401);
+                expect(res.payload.message).to.be.undefined();
 
                 done();
             });
@@ -276,6 +277,7 @@ lab.experiment('hapi-auth-bearer-simple', () => {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(401);
+                expect(res.payload.message).to.be.undefined();
 
                 done();
             });
@@ -318,13 +320,14 @@ lab.experiment('hapi-auth-bearer-simple', () => {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(401);
+                expect(res.payload.message).to.be.undefined();
 
                 done();
             });
         });
     });
 
-    it('Returns badRequest error if authorization header is not bearer', (done) => {
+    it('Returns unAuthorized error if authorization header is not bearer', (done) => {
 
         const validFunc = (token, callback) => {
 
@@ -359,7 +362,8 @@ lab.experiment('hapi-auth-bearer-simple', () => {
             server.inject(request, (res) => {
 
                 expect(res.result).to.exist();
-                expect(res.statusCode).to.equal(400);
+                expect(res.statusCode).to.equal(401);
+                expect(res.payload.message).to.be.undefined();
 
                 done();
             });


### PR DESCRIPTION
I needed to have it return unauthorised as well on the wrong header format.
Otherwise it is not possible to chain it with other schema that depend on the same header field like "Basic".